### PR TITLE
🚀 Release $v2.0.0$: Package Name Correction (Breaking Change)

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,4 +1,4 @@
-package good_money
+package goodmoney
 
 // ISO 4217 Currency codes
 

--- a/currency.go
+++ b/currency.go
@@ -1,4 +1,4 @@
-package good_money
+package goodmoney
 
 import "errors"
 
@@ -32,11 +32,12 @@ func ValidateCurrency(code string) bool {
 // Returns nil if the currency code doesn't exist.
 //
 // Example:
-//   currency := GetCurrency("USD")
-//   if currency != nil {
-//       // currency.NumericCode == "840"
-//       // currency.MinorUnit == 2
-//   }
+//
+//	currency := GetCurrency("USD")
+//	if currency != nil {
+//	    // currency.NumericCode == "840"
+//	    // currency.MinorUnit == 2
+//	}
 func GetCurrency(code string) *Currency {
 	c, err := getCurrency(code)
 	if err != nil {
@@ -49,8 +50,9 @@ func GetCurrency(code string) *Currency {
 // It returns the Currency, the currency code (e.g., "USD"), and an error if the numeric code doesn't exist.
 //
 // Example:
-//   currency, code, err := GetCurrencyByNumericCode("840")
-//   // Returns USD currency, "USD", nil
+//
+//	currency, code, err := GetCurrencyByNumericCode("840")
+//	// Returns USD currency, "USD", nil
 func GetCurrencyByNumericCode(numericCode string) (Currency, string, error) {
 	for code, currency := range CurrencyMap {
 		if currency.NumericCode == numericCode {

--- a/currency_test.go
+++ b/currency_test.go
@@ -1,4 +1,4 @@
-package good_money
+package goodmoney
 
 import (
 	"testing"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/the-nucleus-project/good_money
+module github.com/the-nucleus-project/goodmoney
 
 go 1.21

--- a/money.go
+++ b/money.go
@@ -1,4 +1,4 @@
-package good_money
+package goodmoney
 
 import (
 	"database/sql/driver"

--- a/money_bench_test.go
+++ b/money_bench_test.go
@@ -1,4 +1,4 @@
-package good_money
+package goodmoney
 
 import (
 	"encoding/json"

--- a/money_test.go
+++ b/money_test.go
@@ -1,4 +1,4 @@
-package good_money
+package goodmoney
 
 import (
 	"encoding/json"

--- a/util.go
+++ b/util.go
@@ -1,4 +1,4 @@
-package good_money
+package goodmoney
 
 func absInt64(x int64) int64 {
 	if x < 0 {


### PR DESCRIPTION
## 🚀 Release $v2.0.0$: Package Name Correction (Breaking Change)

This major release addresses an error in the initial $v1.0.0$ release by correcting the official package name and import path.

### ⚠️ **Breaking Change: Module Path & Name**

Renaming the Go module path constitutes a **breaking change** and, according to Semantic Versioning (SemVer) principles, necessitates a major version increment to $v2$.

  * **Module Path Change:** The repository import path has been updated to include the mandatory major version suffix:
      * **Old Path:** `github.com/nucleus-community/good_money`
      * **New Path:** `github.com/nucleus-community/goodmoney`
  * **Package Name Change:** The internal `package` declaration within source files has been updated to the correct name.

### 🛑 **$v1.0.1$ Retraction**

To ensure new users do not encounter the broken $v1.0.0$ release, the version has been officially retracted.

  * A maintenance release ($v1.0.1$) has been tagged solely to add the `retract v1.0.0` directive to the `go.mod` file.
  * **Users should exclusively use the $v2.0.0$ path.**

### 🛠️ Migration Steps for Users

Since the package is new, migration should be simple:

1.  Update your `go.mod` dependency to use `$v2.0.0$`.
2.  Update all import statements in your code to reference the new `/v2` path.


```go
// Before (v1.0.0)
import "github.com/nucleus-community/good_money"

// After (v2.0.0)
import "github.com/nucleus-community/goodmoney"
```